### PR TITLE
Fix contrail-installer to bring up analytics as per updated

### DIFF
--- a/Contrail_user_guide.txt
+++ b/Contrail_user_guide.txt
@@ -51,9 +51,9 @@ Files that are modified in configure phase are
     /etc/contrail/ifcfg-vhost0
     /etc/libvirt/qemu.conf
     /etc/contrail/ctrl-details
-    /etc/contrail/vizd_param
-    /etc/contrail/qed_param
-    /etc/contrail/opserver_param
+    /etc/contrail/contrail-collector.conf
+    /etc/contrail/contrail-query-engine.conf
+    /etc/contrail/contrail-analytics-api.conf
 
 6. Start the contrail services using the command
 

--- a/contrail_config_functions
+++ b/contrail_config_functions
@@ -724,38 +724,20 @@ function fixup_config_files()
     echo 'COMPUTE='$COMPUTE_IP >> "/etc/contrail/ctrl-details"
     echo 'CONTROLLER_MGMT='$CFGM_IP >> "/etc/contrail/ctrl-details"
     if [ "$INSTALL_PROFILE" = "ALL" ]; then
-        REDIS_UVE="/etc/contrail/redis-uve.conf"
-        REDIS_QUERY="/etc/contrail/redis-query.conf"
         REDIS_WEBUI="/etc/contrail/redis-webui.conf"
         if [[ -f /etc/redis/redis.conf ]]; then
             REDIS_CONF="/etc/redis/redis.conf"
         else
             REDIS_CONF="/etc/redis.conf"
         fi
-        sudo cp $REDIS_CONF $REDIS_UVE
-        sudo cp $REDIS_CONF $REDIS_QUERY 
+        sudo sed 's/bind 127.0.0.1.*/#bind 127.0.0.1/g' $REDIS_CONF > redis.conf.new
+        sudo mv redis.conf.new $REDIS_CONF
         sudo cp $REDIS_CONF $REDIS_WEBUI 
-        replace_in_file  $REDIS_UVE  'pidfile /var/run/redis/redis.pid' 'pidfile /var/run/redis/redis-uve.pid'  
-        replace_in_file  $REDIS_UVE  'port 6379' 'port 6381'  
-        replace_in_file  $REDIS_UVE  'bind 127.0.0.1' '#bind 127.0.0.1'  
-        replace_in_file  $REDIS_UVE  'logfile /var/log/redis/redis-server.log' 'logfile /var/log/redis/redis-uve.log'  
-        replace_in_file  $REDIS_UVE  'dbfilename dump.rdb' 'dbfilename dump-uve.rdb'  
-        
-        replace_in_file  $REDIS_QUERY  'pidfile /var/run/redis/redis.pid' 'pidfile /var/run/redis/redis-query.pid'  
-        replace_in_file  $REDIS_QUERY  'port 6379' 'port 6380'  
-        replace_in_file  $REDIS_QUERY  'bind 127.0.0.1' '#bind 127.0.0.1'  
-        replace_in_file  $REDIS_QUERY  'logfile /var/log/redis/redis-server.log' 'logfile /var/log/redis/redis-query.log'  
-        replace_in_file  $REDIS_QUERY  'dbfilename dump.rdb' 'dbfilename dump-query.rdb'    
-        
         replace_in_file  $REDIS_WEBUI  'pidfile /var/run/redis/redis.pid'  'pidfile /var/run/redis/redis-webui.pid'  
         replace_in_file  $REDIS_WEBUI  'port 6379' 'port 6383'  
-        replace_in_file  $REDIS_WEBUI  'bind 127.0.0.1' '#bind 127.0.0.1'  
         replace_in_file  $REDIS_WEBUI  'logfile /var/log/redis/redis-server.log' 'logfile /var/log/redis/redis-webui.log'  
         replace_in_file  $REDIS_WEBUI  'dbfilename dump.rdb' 'dbfilename dump-webui.rdb'    
         
-        replace_vizd_param
-        replace_qed_param
-        replace_opserver
     fi
     if [[ $NON_MGMT_IP ]]; then
        if [[ $NON_MGMT_IP != $COMPUTE_IP ]]; then
@@ -818,90 +800,4 @@ function fixup_config_files()
         :
     fi
     sudo chkconfig network on 
-}
-
-function replace_vizd_param()
-{
-    file="/etc/contrail/vizd_param"
-    cassandra_server=""
-    for ip in ${CASSANDRA_IP_LIST[@]};
-    do
-        cassandra_server=${cassandra_server}""$ip":9160 " 
-    done
-    if [[ -f $file ]]; then
-        sudo rm $file
-    fi
-    check_replace_value $file "" CASSANDRA_SERVER_LIST $cassandra_server
-    check_replace_value $file "" DISCOVERY  $DISCOVERY_IP
-    check_replace_value $file "" HOST_IP  $COLLECTOR_IP
-    check_replace_value $file "" LOG_FILE  '--log-file=/var/log/contrail/collector.log'
-    check_replace_value $file "" LOG_LOCAL  '--log-local'
-    #check_replace_value $file "" REDIS_SERVER $COLLECTOR_IP
-    #check_replace_value $file "" REDIS_SERVER_PORT  6380
-    #check_replace_value $file "" LOG_LEVEL  $__contrail_log_level__
-    #check_replace_value $file "" LISTEN_PORT  $__contrail_listen_port__
-    #check_replace_value $file "" HTTP_SERVER_PORT  $__contrail_http_server_port__
-    remove_spaces $file DEFAULTS
-
-}
-
-function replace_qed_param()
-{
-    file="/etc/contrail/qed_param"
-    cassandra_server=""
-    for ip in ${CASSANDRA_IP_LIST[@]};
-    do
-        cassandra_server=${cassandra_server}""$ip":9160 " 
-    done
-    collector_ip=""
-    for ip in ${COLLECTOR_IP_LIST[@]};
-    do
-        collector_ip=${collector_ip}" "$ip":8086" 
-    done
-    if [[ -f $file ]]; then
-        sudo rm $file
-    fi
-    check_replace_value $file "" CASSANDRA_SERVER_LIST  $cassandra_server
-    check_replace_value $file "" REDIS_SERVER  $COLLECTOR_IP
-    check_replace_value $file "" REDIS_SERVER_PORT  6380
-    check_replace_value $file "" DISCOVERY  $DISCOVERY_IP
-    check_replace_value $file "" COLLECTORS  $collector_ip
-    check_replace_value $file "" LOG_FILE  '--log-file=/var/log/contrail/qe.log'
-    check_replace_value $file "" LOG_LOCAL  '--log-local'
-    #check_replace_value $file "" LOG_LEVEL  $__contrail_log_level__
-    #check_replace_value $file "" LISTEN_PORT  $__contrail_listen_port__
-    #check_replace_value $file "" HTTP_SERVER_PORT  $__contrail_http_server_port__
-    remove_spaces $file DEFAULTS
-
-}
-
-function replace_opserver()
-{
-    file="/etc/contrail/opserver_param"
-    cassandra_server=""
-    for ip in ${CASSANDRA_IP_LIST[@]};
-    do
-        cassandra_server=${cassandra_server}""$ip":9160 " 
-    done
-    if [[ -f $file ]]; then
-        sudo rm $file
-    fi
-    collector_ip=""
-    for ip in ${COLLECTOR_IP_LIST[@]};
-    do
-        collector_ip=${collector_ip}" "$ip":8086" 
-    done
-    check_replace_value $file "" HOST_IP $COLLECTOR_IP
-    check_replace_value $file "" DISCOVERY $DISCOVERY_IP
-    check_replace_value $file "" LOG_LOCAL '--log_local'
-    check_replace_value $file "" LOG_FILE '--log_file=/var/log/contrail/opserver.log'
-    check_replace_value $file "" COLLECTORS $collector_ip
-    #check_replace_value $file "" REDIS_SERVER $COLLECTOR_IP
-    #check_replace_value $file "" REDIS_SERVER_PORT 6380
-    #check_replace_value $file "" REDIS_QUERY_PORT $__contrail_redis_query_port__
-    #check_replace_value $file "" HTTP_SERVER_PORT $__contrail_http_server_port__
-    #check_replace_value $file "" REST_API_PORT $__contrail_rest_api_port__
-    #check_replace_value $file "" LOG_LEVEL $__contrail_log_level__
-    remove_spaces $file DEFAULTS
-
 }

--- a/contrail_config_templates.py
+++ b/contrail_config_templates.py
@@ -164,7 +164,7 @@ ttl_short=1
 ######################################################################
 """)
 
-vizd_param_template = string.Template("""
+contrail_collector_conf_template = string.Template("""
 CASSANDRA_SERVER_LIST=$__contrail_cassandra_server_list__
 REDIS_SERVER=$__contrail_redis_server__
 REDIS_SERVER_PORT=$__contrail_redis_server_port__
@@ -177,7 +177,7 @@ LOG_LOCAL=$__contrail_log_local__
 LOG_LEVEL=$__contrail_log_level__
 """)
 
-qe_param_template = string.Template("""
+contrail_query_conf_template = string.Template("""
 CASSANDRA_SERVER_LIST=$__contrail_cassandra_server_list__
 REDIS_SERVER=$__contrail_redis_server__
 REDIS_SERVER_PORT=$__contrail_redis_server_port__
@@ -190,7 +190,7 @@ LOG_LOCAL=$__contrail_log_local__
 LOG_LEVEL=$__contrail_log_level__
 """)
 
-opserver_param_template = string.Template("""
+contrail_analytics_api_template = string.Template("""
 REDIS_SERVER=$__contrail_redis_server__
 REDIS_SERVER_PORT=$__contrail_redis_server_port__
 REDIS_QUERY_PORT=$__contrail_redis_query_port__

--- a/service.sh
+++ b/service.sh
@@ -71,34 +71,23 @@ function _start_service()
                     fi
                    ;;
 
-           redis-u) echo "starting redis-u"
-                    screen_it redis-u "sudo redis-server /etc/contrail/redis-uve.conf"
-                   ;;
-
-           redis-q) echo "starting redis-q"
-                    screen_it redis-q "sudo redis-server /etc/contrail/redis-query.conf"
-                   ;;
-
-           vizd) echo "starting vizd"
-                 source /etc/contrail/vizd_param
+           collector) echo "starting collector"
                  if [[ "$CONTRAIL_DEFAULT_INSTALL" != "True" ]]; then
-                    screen_it vizd "sudo PATH=$PATH:$TOP_DIR/bin LD_LIBRARY_PATH=/opt/stack/contrail/build/lib $CONTRAIL_SRC/build/production/analytics/vizd --DEFAULT.cassandra_server_list ${CASSANDRA_SERVER_LIST} --DEFAULT.hostip ${HOST_IP} --DEFAULT.log_file /var/log/contrail/collector.log"
+                    screen_it collector "sudo PATH=$PATH:$TOP_DIR/bin LD_LIBRARY_PATH=/opt/stack/contrail/build/lib $CONTRAIL_SRC/build/production/analytics/vizd"
                  else
-                    screen_it vizd "sudo PATH=$PATH:/usr/bin LD_LIBRARY_PATH=/usr/lib /usr/bin/vizd --DEFAULT.cassandra_server_list ${CASSANDRA_SERVER_LIST} --DEFAULT.hostip ${HOST_IP} --DEFAULT.log_file /var/log/contrail/collector.log"
+                    screen_it collector "sudo PATH=$PATH:/usr/bin LD_LIBRARY_PATH=/usr/lib /usr/bin/contrail-collector"
                  fi
                    ;;
  
-          opserver) echo "starting opserver"
-                    source /etc/contrail/opserver_param
-                    screen_it opserver "python  $(pywhere opserver)/opserver.py --collectors ${COLLECTORS} --host_ip ${HOST_IP} ${LOG_FILE} ${LOG_LOCAL}"
+          analytics-api) echo "starting analytics-api"
+                    screen_it analytics-api "python  $(pywhere opserver)/opserver.py"
                    ;;
 
-          qed) echo "starting qed"
-               source /etc/contrail/qed_param
+          query-engine) echo "starting query-engine"
                if [[ "$CONTRAIL_DEFAULT_INSTALL" != "True" ]]; then  
-                   screen_it qed "sudo PATH=$PATH:$TOP_DIR/bin LD_LIBRARY_PATH=/opt/stack/contrail/build/lib $CONTRAIL_SRC/build/production/query_engine/qed --DEFAULT.collectors ${COLLECTORS} --DEFAULT.cassandra_server_list ${CASSANDRA_SERVER_LIST} --REDIS.server ${REDIS_SERVER} --REDIS.port ${REDIS_SERVER_PORT} --DEFAULT.log_file /var/log/contrail/qe.log --DEFAULT.log_local"
+                   screen_it query-engine "sudo PATH=$PATH:$TOP_DIR/bin LD_LIBRARY_PATH=/opt/stack/contrail/build/lib $CONTRAIL_SRC/build/production/query_engine/qed"
                else
-                    screen_it qed "sudo PATH=$PATH:/usr/bin LD_LIBRARY_PATH=/usr/lib /usr/bin/qed --DEFAULT.collectors ${COLLECTORS} --DEFAULT.cassandra_server_list ${CASSANDRA_SERVER_LIST} --REDIS.server ${REDIS_SERVER} --REDIS.port ${REDIS_SERVER_PORT} --DEFAULT.log_file /var/log/contrail/qe.log --DEFAULT.log_local"
+                    screen_it query-engine "sudo PATH=$PATH:/usr/bin LD_LIBRARY_PATH=/usr/lib /usr/bin/contrail-query-engine"
                fi
                    ;;
 


### PR DESCRIPTION
changes in contrail-controller using just one redis server.
Renamed vizd, opserver, qed to collector, analytics-api, and
query-engine.
