### PR TITLE
Fix for Q_PLUGIN_CLASS in devstack localrc-all

### DIFF
--- a/devstack/samples/localrc-all
+++ b/devstack/samples/localrc-all
@@ -34,4 +34,4 @@ NOVA_VIF_DRIVER=nova_contrail_vif.contrailvif.VRouterVIFDriver
 
 # may need the following for older trunk snapshot
 # validate against /usr/lib/python2.7/dist-packages/neutron_plugin_contrail/plugins/opencontrail/
-Q_PLUGIN_CLASS=neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_core.NeutronPluginContrailCoreV2
+Q_PLUGIN_CLASS=neutron_plugin_contrail.plugins.opencontrail.contrail_plugin.NeutronPluginContrailCoreV2


### PR DESCRIPTION
when using contrail-installer in binary mode,
neutron-plugin-contrail debian pkg doesn't have
contrail_plugin_core.py file to load neutron core_plugin,
hence neutron failed to start.
