### PR TITLE
This change conforms the script to the new packaging/process-mgmt

### DIFF
--- a/contrail.sh
+++ b/contrail.sh
@@ -791,7 +791,7 @@ function pywhere() {
 
 function stop_contrail_services() {
 
-    services=(contrail-analytics-api contrail-control contrail-query-engine contrail-vrouter-agent contrail-api contrail-discovery contrail-schema contrail-webui-jobserver contrail-collector contrail-dns contrail-svc-monitor contrail-webui-webserver ifmap-server)
+    services=(supervisor-analytics supervisor-control supervisor-config supervisor-vrouter contrail-analytics-api contrail-control contrail-query-engine contrail-vrouter-agent contrail-api contrail-discovery contrail-schema contrail-webui-jobserver contrail-collector contrail-dns contrail-svc-monitor contrail-webui-webserver ifmap-server)
     for service in ${services[@]} 
     do
         sudo service $service stop


### PR DESCRIPTION
scheme where supervisor instances for each node manages individual
contrail services such contrail-collector, contrail-config etc.

That is why while shutting down the services, we need to shut down
supervisor instances too.

Closes-PR: 1354579
