### PR TITLE
Instead of chkconfig,sysv-rc-conf is used for trusty

### DIFF
--- a/contrail.sh
+++ b/contrail.sh
@@ -271,7 +271,12 @@ function download_dependencies {
         apt_get install python-setuptools
         apt_get install python-novaclient
         apt_get install curl
-        apt_get install chkconfig screen
+	if [[ "$DISTRO" != "trusty" ]]; then
+            apt_get install chkconfig
+        else
+            apt_get install sysv-rc-conf
+        fi
+        apt_get install screen
         apt_get install default-jdk javahelper
         apt_get install libcommons-codec-java libhttpcore-java liblog4j1.2-java
 	apt_get install python-software-properties
@@ -340,6 +345,9 @@ function download_python_dependencies {
     pip_install -U setuptools
     pip_install amqp
     
+    #Updating the rootwrap fetched by python-neutron
+    pip_install -U oslo.rootwrap
+
     if [ "$INSTALL_PROFILE" = "ALL" ]; then
         if is_ubuntu; then
             :
@@ -659,6 +667,8 @@ function install_contrail() {
                 apt_get install ifmap-server 
                 apt_get install python-ncclient
 
+		#Updating the messaging installed by python-nova
+                pip_install -U oslo.messaging
                 # contrail neutron plugin installs ini file as root
                 sudo chown -R `whoami`:`whoami` /etc/neutron
             fi

--- a/contrail_config_functions
+++ b/contrail_config_functions
@@ -718,7 +718,11 @@ function fixup_config_files()
     setenforce 0
 
     # Disable iptables      
-    sudo chkconfig iptables off
+    if [[ "$DISTRO" != "trusty" ]]; then
+        sudo chkconfig iptables off
+    else
+        sudo sysv-rc-conf iptables off
+    fi
     sudo iptables --flush 
     
     sudo rm /etc/contrail/ctrl-details
@@ -804,5 +808,10 @@ function fixup_config_files()
         #migrate_routes $dev
         :
     fi
-    sudo chkconfig network on 
+    if [[ "$DISTRO" != "trusty" ]]; then
+        sudo chkconfig network on
+    else
+        sudo sysv-rc-conf network on
+    fi
+
 }


### PR DESCRIPTION
Instead of chkconfig,sysv-rc-conf is used for trusty