### PR TITLE
Install automatically redis dependencies

### DIFF
--- a/contrail.sh
+++ b/contrail.sh
@@ -247,7 +247,7 @@ function download_redis {
     echo "Downloading dependencies"
     if is_ubuntu; then
         if ! which redis-server > /dev/null 2>&1 ; then
-            sudo apt-get install redis-server
+            sudo apt-get -y install redis-server
             sudo service redis-server stop
         fi
     else


### PR DESCRIPTION
Currently apt will stop its execution and prompt the user to install
redis dependencies.

This allows to run the script without any interaction.