### PR TITLE
Install libipfix-dev dependency

### DIFF
--- a/contrail.sh
+++ b/contrail.sh
@@ -319,7 +319,7 @@ function download_dependencies {
             apt_get install python-lxml python-redis python-jsonpickle
             apt_get install ant debhelper 
             apt_get install linux-headers-$(uname -r)
-            apt_get install libipfix
+            apt_get install libipfix libipfix-dev
             apt_get install python-docker-py
         fi	
         apt_get install python-neutron


### PR DESCRIPTION
I encountered the following error at contrail build time:
2015-09-29 19:53:30 g++ -o build/production/analytics/viz_collector.o -c -g -O3 -Wall -Werror -Wsign-compare -Wno-unused-local-typedefs -DLINUX -Icontroller/src -Ibuild/include -Icontroller/lib -I/usr/include/python2.7 -I/usr/include/librdkafka -Ibuild/production/tools/sandesh/library/common -Itools/sandesh/library/common -Ibuild/production/io -Icontroller/src/io -Ibuild/production -Icontroller/src/gendb -Ibuild/include/thrift -Ibuild/production/http/client -Icontroller/src/http/client -Ibuild/production/discovery/client -Icontroller/src/discovery/client -Ibuild/production/gendb -Icontroller/src/gendb -Ibuild/production/cdb -Icontroller/src/cdb -Ibuild/production/analytics -Icontroller/src/analytics -Ibuild/production -Ibuild/production/base/sandesh -Icontroller/src/base/sandesh controller/src/analytics/viz_collector.cc
2015-09-29 19:53:31 In file included from controller/src/analytics/viz_collector.cc:22:0:
2015-09-29 19:53:31 controller/src/analytics/ipfix_collector.h:12:19: fatal error: ipfix.h: No such file or directory
2015-09-29 19:53:31  #include "ipfix.h"
2015-09-29 19:53:31                    ^
2015-09-29 19:53:31 compilation terminated.
2015-09-29 19:53:35 scons: *** [build/production/analytics/viz_collector.o] Error 1
2015-09-29 19:53:35 scons: building terminated because of errors.

I then add this dependency somewhere in contrail.sh but not sure it's the right place...

