### PR TITLE
Fix the url path to retrieve Cassandra CPP driver debian package

### DIFF
--- a/contrail.sh
+++ b/contrail.sh
@@ -486,8 +486,8 @@ function repo_initialize_backup {
 function download_cassandra_cpp_drivers {
     echo "Downloading cassanadra CPP drivers"
     if is_ubuntu; then
-        wget http://downloads.datastax.com/cpp-driver/ubuntu/14.04/v2.2.0/cassandra-cpp-driver_2.2.0-1_amd64.deb
-        wget http://downloads.datastax.com/cpp-driver/ubuntu/14.04/v2.2.0/cassandra-cpp-driver-dev_2.2.0-1_amd64.deb
+        wget http://downloads.datastax.com/cpp-driver/ubuntu/14.04/cassandra/v2.2.0/cassandra-cpp-driver_2.2.0-1_amd64.deb
+        wget http://downloads.datastax.com/cpp-driver/ubuntu/14.04/cassandra/v2.2.0/cassandra-cpp-driver-dev_2.2.0-1_amd64.deb
         wget http://downloads.datastax.com/cpp-driver/ubuntu/14.04/dependencies/libuv/v1.7.5/libuv_1.7.5-1_amd64.deb
         sudo dpkg -i cassandra-cpp-driver_2.2.0-1_amd64.deb cassandra-cpp-driver-dev_2.2.0-1_amd64.deb libuv_1.7.5-1_amd64.deb
     fi


### PR DESCRIPTION
The url path for cassandra cpp driver has changed in downloads.datastax.com.

This commit points the download to the proper url.